### PR TITLE
New translate.zig from tigerbeetle (handles modern Zig)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Node.js Native Module written in Zig
 
+Forked from https://github.com/felixdrp/zig-nodejs-example. Updated to Zig >= 0.11 (copied over the latest https://github.com/tigerbeetle/tigerbeetle/blob/main/src/clients/node/src/translate.zig with some minimal changes). Tested with zig 0.11, 0.12, 0.13 and master. Tested with cross-compililation to package a node aws lambda function.
+
 Node.js Native Modules are typically written in C++, but you can write them also in other languages like Rust ([1], [2]), too. [Zig](https://ziglang.org/) is a new low-level programming language that competes with C, integrating seemlessly with C libraries without FFI or bindings.
 
 This project is an example Hello World for making a Node.js native module in Zig.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Example of a Node.js module written in Zig",
   "main": "index.js",
   "scripts": {
-    "build": "mkdir -p dist && ZIG_SYSTEM_LINKER_HACK=1 zig build-lib -mcpu=baseline -OReleaseSmall -dynamic -lc -isystem deps/node-$(node --version)/include/node src/lib.zig -fallow-shlib-undefined -femit-bin=dist/lib.node",
+      "build-x86": "mkdir -p dist && zig build-lib -target x86_64-linux-gnu -mcpu=baseline -OReleaseSmall -dynamic -lc -isystem deps/node-$(node --version)/include/node src/lib.zig -fallow-shlib-undefined -femit-bin=dist/lib.node",
+      "build": "mkdir -p dist && zig build-lib -mcpu=baseline -OReleaseSmall -dynamic -lc -isystem deps/node-$(node --version)/include/node src/lib.zig -fallow-shlib-undefined -femit-bin=dist/lib.node",
     "test": "node test.js",
     "postinstall": "./download-node-headers.sh"
   },

--- a/src/translate.zig
+++ b/src/translate.zig
@@ -1,17 +1,3 @@
-// SPDX-FileCopyrightText: 2021 Coil Technologies, Inc
-//
-// SPDX-License-Identifier: Apache-2.0
-
-// References:
-// https://github.com/staltz/zig-nodejs-example
-// https://github.com/tigerbeetledb/tigerbeetle-node
-
-// Fix error: parameter of type 'fn' must be declared comptime
-// https://stackoverflow.com/questions/74251650/how-to-pass-zig-function-pointers-to-other-functions
-// Starting with 0.10, there are 2 ways to pass a function as an argument:
-// As a function body. Must be comptime-known.
-// As a function pointer.
-
 const std = @import("std");
 const assert = std.debug.assert;
 const c = @import("c.zig");
@@ -20,21 +6,26 @@ pub fn register_function(
     env: c.napi_env,
     exports: c.napi_value,
     comptime name: [:0]const u8,
-    comptime function: fn (env: c.napi_env, info: c.napi_callback_info) callconv(.C) c.napi_value,
+    function: *const fn (env: c.napi_env, info: c.napi_callback_info) callconv(.C) c.napi_value,
 ) !void {
     var napi_function: c.napi_value = undefined;
     if (c.napi_create_function(env, null, 0, function, null, &napi_function) != c.napi_ok) {
         return throw(env, "Failed to create function " ++ name ++ "().");
     }
 
-    if (c.napi_set_named_property(env, exports, name, napi_function) != c.napi_ok) {
+    if (c.napi_set_named_property(
+        env,
+        exports,
+        @as([*c]const u8, @ptrCast(name)),
+        napi_function,
+    ) != c.napi_ok) {
         return throw(env, "Failed to add " ++ name ++ "() to exports.");
     }
 }
 
 const TranslationError = error{ExceptionThrown};
 pub fn throw(env: c.napi_env, comptime message: [:0]const u8) TranslationError {
-    var result = c.napi_throw_error(env, null, message);
+    const result = c.napi_throw_error(env, null, @as([*c]const u8, @ptrCast(message)));
     switch (result) {
         c.napi_ok, c.napi_pending_exception => {},
         else => unreachable,
@@ -43,23 +34,39 @@ pub fn throw(env: c.napi_env, comptime message: [:0]const u8) TranslationError {
     return TranslationError.ExceptionThrown;
 }
 
-pub fn capture_undefined(env: c.napi_env) !c.napi_value {
+pub fn capture_null(env: c.napi_env) !c.napi_value {
     var result: c.napi_value = undefined;
-    if (c.napi_get_undefined(env, &result) != c.napi_ok) {
-        return throw(env, "Failed to capture the value of \"undefined\".");
+    if (c.napi_get_null(env, &result) != c.napi_ok) {
+        return throw(env, "Failed to capture the value of \"null\".");
     }
 
     return result;
 }
 
-pub fn set_instance_data(
-    env: c.napi_env,
-    data: *anyopaque,
-    finalize_callback: fn (env: c.napi_env, data: ?*anyopaque, hint: ?*anyopaque) callconv(.C) void,
-) !void {
-    if (c.napi_set_instance_data(env, data, finalize_callback, null) != c.napi_ok) {
-        return throw(env, "Failed to initialize environment.");
+pub fn extract_args(env: c.napi_env, info: c.napi_callback_info, comptime args: struct {
+    count: usize,
+    function: []const u8,
+}) ![args.count]c.napi_value {
+    var argc = args.count;
+    var argv: [args.count]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throw(
+            env,
+            std.fmt.comptimePrint("Failed to get args for {s}()\x00", .{args.function}),
+        );
     }
+
+    if (argc != args.count) {
+        return throw(
+            env,
+            std.fmt.comptimePrint("Function {s}() requires exactly {} arguments.\x00", .{
+                args.function,
+                args.count,
+            }),
+        );
+    }
+
+    return argv;
 }
 
 pub fn create_external(env: c.napi_env, context: *anyopaque) !c.napi_value {
@@ -82,40 +89,6 @@ pub fn value_external(
     }
 
     return result;
-}
-
-pub const UserData = packed struct {
-    env: c.napi_env,
-    callback_reference: c.napi_ref,
-};
-
-/// This will create a reference in V8 with a ref_count of 1.
-/// This reference will be destroyed when we return the server response to JS.
-pub fn user_data_from_value(env: c.napi_env, value: c.napi_value) !UserData {
-    var callback_type: c.napi_valuetype = undefined;
-    if (c.napi_typeof(env, value, &callback_type) != c.napi_ok) {
-        return throw(env, "Failed to check callback type.");
-    }
-    if (callback_type != c.napi_function) return throw(env, "Callback must be a Function.");
-
-    var callback_reference: c.napi_ref = undefined;
-    if (c.napi_create_reference(env, value, 1, &callback_reference) != c.napi_ok) {
-        return throw(env, "Failed to create reference to callback.");
-    }
-
-    return UserData{
-        .env = env,
-        .callback_reference = callback_reference,
-    };
-}
-
-pub fn globals(env: c.napi_env) !?*anyopaque {
-    var data: ?*anyopaque = null;
-    if (c.napi_get_instance_data(env, &data) != c.napi_ok) {
-        return throw(env, "Failed to decode globals.");
-    }
-
-    return data;
 }
 
 pub fn slice_from_object(
@@ -147,50 +120,7 @@ pub fn slice_from_value(
 
     if (data_length < 1) return throw(env, key ++ " must not be empty");
 
-    return @ptrCast([*]u8, data.?)[0..data_length];
-}
-
-pub fn bytes_from_object(
-    env: c.napi_env,
-    object: c.napi_value,
-    comptime length: u8,
-    comptime key: [:0]const u8,
-) ![length]u8 {
-    var property: c.napi_value = undefined;
-    if (c.napi_get_named_property(env, object, key, &property) != c.napi_ok) {
-        return throw(env, key ++ " must be defined");
-    }
-
-    const data = try slice_from_value(env, property, key);
-    if (data.len != length) {
-        return throw(env, key ++ " has incorrect length.");
-    }
-
-    // Copy this out of V8 as the underlying data lifetime is not guaranteed.
-    var result: [length]u8 = undefined;
-    std.mem.copy(u8, result[0..], data[0..]);
-
-    return result;
-}
-
-pub fn bytes_from_buffer(
-    env: c.napi_env,
-    buffer: c.napi_value,
-    output: []u8,
-    comptime key: [:0]const u8,
-) !usize {
-    const data = try slice_from_value(env, buffer, key);
-    if (data.len < 1) {
-        return throw(env, key ++ " must not be empty.");
-    }
-    if (data.len > output.len) {
-        return throw(env, key ++ " exceeds max message size.");
-    }
-
-    // Copy this out of V8 as the underlying data lifetime is not guaranteed.
-    std.mem.copy(u8, output[0..], data[0..]);
-
-    return data.len;
+    return @as([*]u8, @ptrCast(data.?))[0..data_length];
 }
 
 pub fn u128_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]const u8) !u128 {
@@ -222,21 +152,22 @@ pub fn u32_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]
 
 pub fn u16_from_object(env: c.napi_env, object: c.napi_value, comptime key: [:0]const u8) !u16 {
     const result = try u32_from_object(env, object, key);
-    if (result > 65535) {
+    if (result > std.math.maxInt(u16)) {
         return throw(env, key ++ " must be a u16.");
     }
 
-    return @intCast(u16, result);
+    return @as(u16, @intCast(result));
 }
 
 pub fn u128_from_value(env: c.napi_env, value: c.napi_value, comptime name: [:0]const u8) !u128 {
-    // A BigInt's value (using ^ to mean exponent) is (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
+    // A BigInt's value (using ^ to mean exponent) is
+    // (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...).
 
     // V8 says that the words are little endian. If we were on a big endian machine
     // we would need to convert, but big endian is not supported by tigerbeetle.
     var result: u128 = 0;
     var sign_bit: c_int = undefined;
-    const words = @ptrCast(*[2]u64, &result);
+    const words: *[2]u64 = @ptrCast(&result);
     var word_count: usize = 2;
     switch (c.napi_get_value_bigint_words(env, value, &sign_bit, &word_count, words)) {
         c.napi_ok => {},
@@ -275,24 +206,6 @@ pub fn u32_from_value(env: c.napi_env, value: c.napi_value, comptime name: [:0]c
     return result;
 }
 
-pub fn byte_slice_into_object(
-    env: c.napi_env,
-    object: c.napi_value,
-    comptime key: [:0]const u8,
-    value: []const u8,
-    comptime error_message: [:0]const u8,
-) !void {
-    var result: c.napi_value = undefined;
-    // create a copy that is managed by V8.
-    if (c.napi_create_buffer_copy(env, value.len, value.ptr, null, &result) != c.napi_ok) {
-        return throw(env, error_message ++ " Failed to allocate Buffer in V8.");
-    }
-
-    if (c.napi_set_named_property(env, object, key, result) != c.napi_ok) {
-        return throw(env, error_message);
-    }
-}
-
 pub fn u128_into_object(
     env: c.napi_env,
     object: c.napi_value,
@@ -300,7 +213,8 @@ pub fn u128_into_object(
     value: u128,
     comptime error_message: [:0]const u8,
 ) !void {
-    // A BigInt's value (using ^ to mean exponent) is (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
+    // A BigInt's value (using ^ to mean exponent) is
+    // (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...).
 
     // V8 says that the words are little endian. If we were on a big endian machine
     // we would need to convert, but big endian is not supported by tigerbeetle.
@@ -309,13 +223,18 @@ pub fn u128_into_object(
         env,
         0,
         2,
-        @ptrCast(*const [2]u64, &value),
+        @as(*const [2]u64, @ptrCast(&value)),
         &bigint,
     ) != c.napi_ok) {
         return throw(env, error_message);
     }
 
-    if (c.napi_set_named_property(env, object, key, bigint) != c.napi_ok) {
+    if (c.napi_set_named_property(
+        env,
+        object,
+        @ptrCast(key),
+        bigint,
+    ) != c.napi_ok) {
         return throw(env, error_message);
     }
 }
@@ -332,7 +251,12 @@ pub fn u64_into_object(
         return throw(env, error_message);
     }
 
-    if (c.napi_set_named_property(env, object, key, result) != c.napi_ok) {
+    if (c.napi_set_named_property(
+        env,
+        object,
+        @ptrCast(key),
+        result,
+    ) != c.napi_ok) {
         return throw(env, error_message);
     }
 }
@@ -349,7 +273,7 @@ pub fn u32_into_object(
         return throw(env, error_message);
     }
 
-    if (c.napi_set_named_property(env, object, key, result) != c.napi_ok) {
+    if (c.napi_set_named_property(env, object, @ptrCast(key), result) != c.napi_ok) {
         return throw(env, error_message);
     }
 }
@@ -369,31 +293,6 @@ pub fn create_object(env: c.napi_env, comptime error_message: [:0]const u8) !c.n
     if (c.napi_create_object(env, &result) != c.napi_ok) {
         return throw(env, error_message);
     }
-
-    return result;
-}
-
-pub fn create_string(env: c.napi_env, value: [:0]const u8) !c.napi_value {
-    var result: c.napi_value = undefined;
-    if (c.napi_create_string_utf8(env, value, value.len, &result) != c.napi_ok) {
-        return throw(env, "Failed to create string");
-    }
-
-    return result;
-}
-
-fn create_buffer(
-    env: c.napi_env,
-    value: []const u8,
-    comptime error_message: [:0]const u8,
-) !c.napi_value {
-    var data: ?*anyopaque = undefined;
-    var result: c.napi_value = undefined;
-    if (c.napi_create_buffer(env, value.len, &data, &result) != c.napi_ok) {
-        return throw(env, error_message);
-    }
-
-    std.mem.copy(u8, @ptrCast([*]u8, data.?)[0..value.len], value[0..value.len]);
 
     return result;
 }
@@ -449,46 +348,20 @@ pub fn delete_reference(env: c.napi_env, reference: c.napi_ref) !void {
     }
 }
 
-pub fn create_error(
-    env: c.napi_env,
-    comptime message: [:0]const u8,
-) TranslationError!c.napi_value {
-    var napi_string: c.napi_value = undefined;
-    if (c.napi_create_string_utf8(env, message, std.mem.len(message), &napi_string) != c.napi_ok) {
-        return TranslationError.ExceptionThrown;
-    }
-
-    var napi_error: c.napi_value = undefined;
-    if (c.napi_create_error(env, null, napi_string, &napi_error) != c.napi_ok) {
-        return TranslationError.ExceptionThrown;
-    }
-
-    return napi_error;
-}
-
 pub fn call_function(
     env: c.napi_env,
     this: c.napi_value,
     callback: c.napi_value,
-    argc: usize,
-    argv: [*]c.napi_value,
-) !void {
-    const result = c.napi_call_function(env, this, callback, argc, argv, null);
-    switch (result) {
+    args: []c.napi_value,
+) !c.napi_value {
+    var result: c.napi_value = undefined;
+    switch (c.napi_call_function(env, this, callback, args.len, args.ptr, &result)) {
         c.napi_ok => {},
         // the user's callback may throw a JS exception or call other functions that do so. We
         // therefore don't throw another error.
         c.napi_pending_exception => {},
         else => return throw(env, "Failed to invoke results callback."),
     }
-}
-
-pub fn scope(env: c.napi_env, comptime error_message: [:0]const u8) !c.napi_value {
-    var result: c.napi_value = undefined;
-    if (c.napi_get_global(env, &result) != c.napi_ok) {
-        return throw(env, error_message);
-    }
-
     return result;
 }
 
@@ -500,6 +373,15 @@ pub fn reference_value(
     var result: c.napi_value = undefined;
     if (c.napi_get_reference_value(env, callback_reference, &result) != c.napi_ok) {
         return throw(env, error_message);
+    }
+
+    return result;
+}
+
+pub fn create_string(env: c.napi_env, value: [:0]const u8) !c.napi_value {
+    var result: c.napi_value = undefined;
+    if (c.napi_create_string_utf8(env, value, value.len, &result) != c.napi_ok) {
+        return throw(env, "Failed to create string");
     }
 
     return result;


### PR DESCRIPTION
I couldn't get the original example to work - on zig 0.10 the C import failed, on 0.11 and later the library didn't compile. I fixed it by fetching the latest translate.zig from tigerbeetle and adding a small function